### PR TITLE
New feature: Use the "last-modified time" returned by server as the "access and modified times" of the downloaded *.vtt or *.srt files

### DIFF
--- a/isubrip/commands/download.py
+++ b/isubrip/commands/download.py
@@ -265,7 +265,7 @@ async def download_subtitles(scraper: Scraper, media_data: Movie | Episode, down
                 progress_bar.update(task, advance=1, description=f"Processing [magenta]{language_info}[/magenta]")
 
             try:
-                subtitles_data = await scraper.download_subtitles(media_data=matching_subtitles_item,
+                subtitles_data, subtitles_datetime = await scraper.download_subtitles(media_data=matching_subtitles_item,
                                                                   subrip_conversion=convert_to_srt)
 
             except Exception as e:
@@ -287,6 +287,7 @@ async def download_subtitles(scraper: Scraper, media_data: Movie | Episode, down
                     output_path=temp_download_path,
                     source_abbreviation=scraper.abbreviation,
                     overwrite=overwrite_existing,
+                    file_datetime=subtitles_datetime,
                 ))
 
                 downloaded_subtitles.append(f"• {language_info}")

--- a/isubrip/utils.py
+++ b/isubrip/utils.py
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
     import httpx
     from pydantic import BaseModel, ValidationError
 
+import os
+
 
 class SingletonMeta(ABCMeta):
     """
@@ -141,7 +143,7 @@ def convert_log_level(log_level: str) -> int:
 
 
 def download_subtitles_to_file(media_data: Movie | Episode, subtitles_data: SubtitlesData, output_path: str | PathLike,
-                               source_abbreviation: str | None = None, overwrite: bool = False) -> Path:
+                               source_abbreviation: str | None = None, overwrite: bool = False, file_datetime: float | None = None) -> Path:
     """
     Download subtitles to a file.
 
@@ -189,6 +191,8 @@ def download_subtitles_to_file(media_data: Movie | Episode, subtitles_data: Subt
 
     with file_path.open('wb') as f:
         f.write(subtitles_data.content)
+        if file_datetime is not None:
+            os.utime(file_path, (file_datetime, file_datetime))
 
     return file_path
 


### PR DESCRIPTION
![未命名-2](https://github.com/user-attachments/assets/1f571692-aa34-40a8-a106-e26cc81719bf)

Hi, thanks for developing iSubRip, it's a very useful tool.

I implement a new feature to keep the server time on the downloaded subtile file as a kind of record of the subtitle version.

If you don't mind, maybe this commit could be merged to the main branch, thank you.